### PR TITLE
Add NotificationChannels resource and integrate with recipient entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes will be documented in this file.
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
 ## [Unreleased]
+- Add `NotificationChannels` resource
+- Add `EnvelopeRecipient.notificationChannels` property
+- Add `EnvelopeTemplateRecipient.notificationChannels` property
+- Add `EnvelopeTemplateRecipientDefaults.notificationChannels` property
 - Add `MyBulkSign.bulkSignatures` endpoint
 - Add `MyBulkSign.envelopes` endpoint
 - Add `UserBulkSignEnvelope` resource

--- a/src/Resource/EnvelopeRecipient.php
+++ b/src/Resource/EnvelopeRecipient.php
@@ -124,4 +124,6 @@ class EnvelopeRecipient extends BaseResource
     public ?DateTime $birthdate = null;
 
     public ?string $birthnumber = null;
+
+    public NotificationChannels $notificationChannels;
 }

--- a/src/Resource/EnvelopeTemplateRecipient.php
+++ b/src/Resource/EnvelopeTemplateRecipient.php
@@ -85,4 +85,6 @@ class EnvelopeTemplateRecipient extends BaseResource
     public ?DateTime $birthdate = null;
 
     public ?string $birthnumber = null;
+
+    public NotificationChannels $notificationChannels;
 }

--- a/src/Resource/EnvelopeTemplateRecipientDefaults.php
+++ b/src/Resource/EnvelopeTemplateRecipientDefaults.php
@@ -46,4 +46,6 @@ class EnvelopeTemplateRecipientDefaults extends BaseResource
     public bool $approveDocumentsAtOnce;
 
     public bool $signDocumentsAtOnce;
+
+    public NotificationChannels $notificationChannels;
 }

--- a/src/Resource/NotificationChannels.php
+++ b/src/Resource/NotificationChannels.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCz\DigiSign\Resource;
+
+use DigitalCz\DigiSign\Resource\Traits\EntityResourceTrait;
+
+class NotificationChannels extends BaseResource
+{
+    use EntityResourceTrait;
+
+    public string $declined;
+
+    public string $disapproved;
+
+    public string $expired;
+
+    public string $authFailed;
+
+    public string $deliveryFailed;
+
+    public string $identificationDenied;
+
+    public string $deleted;
+
+    public string $cancelled;
+}


### PR DESCRIPTION
- Add new NotificationChannels resource with notification channel properties
- Add notificationChannels property to EnvelopeRecipient
- Add notificationChannels property to EnvelopeTemplateRecipient
- Add notificationChannels property to EnvelopeTemplateRecipientDefaults

<!--- Provide a general summary of your changes in the Title above -->

## Description

Describe your changes in detail.

## Motivation and context

Why is this change required? What problem does it solve?

If it fixes an open issue, please link to the issue here (if you write `fixes #num`
or `closes #num`, the issue will be automatically closed when the pull is accepted.)

## How has this been tested?

Please describe in detail how you tested your changes.

Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!