### PR TITLE
Add `PreciseDateTime` class and update related fields in `AccountRequ…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,11 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Add `MyInfo.intercomToken` property
 - Add `IdentifyScenarioVersion.identificationType` property
 - Add `IdentifyScenarioVersion.bankIdScopes` property
-
 - Update `MyEnvelope` resource
 - Update `IdentityProvider` resource
 - Add `SentEnvelopeReport.validTo` in to resource
+- Add `PreciseDateTime` class to indicate DateTime with milliseconds'
+- Changed `AccountRequest.requestTime` and `AccountRequest.responseTime` type to `PreciseDateTime`
 
 ## [2.8.1] - 2025-06-23
 - Rename `AccountBilling.fileUploadLimit` to `AccountBilling.fileSizeLimit`

--- a/src/Resource/AccountRequest.php
+++ b/src/Resource/AccountRequest.php
@@ -33,9 +33,9 @@ class AccountRequest extends BaseResource
 
     public ?Blame $createdBy = null;
 
-    public DateTime $requestTime;
+    public PreciseDateTime $requestTime;
 
-    public DateTime $responseTime;
+    public PreciseDateTime $responseTime;
 
     public int $duration;
 }

--- a/src/Resource/BaseResource.php
+++ b/src/Resource/BaseResource.php
@@ -59,7 +59,7 @@ class BaseResource implements ResourceInterface
             }
 
             if ($value instanceof PreciseDateTime) {
-                $value = $value->format('Y-m-d\TH:i:s.vP');
+                $value = $value->format(PreciseDateTime::MILLIS);
             } elseif ($value instanceof DateTimeInterface) {
                 $value = $value->format(DateTimeInterface::ATOM);
             }

--- a/src/Resource/BaseResource.php
+++ b/src/Resource/BaseResource.php
@@ -58,7 +58,9 @@ class BaseResource implements ResourceInterface
                 continue;
             }
 
-            if ($value instanceof DateTimeInterface) {
+            if ($value instanceof PreciseDateTime) {
+                $value = $value->format('Y-m-d\TH:i:s.vP');
+            } elseif ($value instanceof DateTimeInterface) {
                 $value = $value->format(DateTimeInterface::ATOM);
             }
 
@@ -173,12 +175,12 @@ class BaseResource implements ResourceInterface
                 $value = new Collection($value, $resourceClass);
             }
 
-            if ($type === DateTime::class) {
+            if ($type === DateTime::class || $type === PreciseDateTime::class) {
                 if (!is_string($value)) {
                     throw new RuntimeException('Unexpected value for DateTime field');
                 }
 
-                $value = new DateTime($value);
+                $value = new $type($value);
             }
         }
 

--- a/src/Resource/PreciseDateTime.php
+++ b/src/Resource/PreciseDateTime.php
@@ -11,4 +11,5 @@ use DateTime;
  */
 class PreciseDateTime extends DateTime
 {
+    public const MILLIS = 'Y-m-d\TH:i:s.vP';
 }

--- a/src/Resource/PreciseDateTime.php
+++ b/src/Resource/PreciseDateTime.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCz\DigiSign\Resource;
+
+use DateTime;
+
+/**
+ * DateTime class that always includes milliseconds in serialization
+ */
+class PreciseDateTime extends DateTime
+{
+}

--- a/tests/Resource/BaseResourceTest.php
+++ b/tests/Resource/BaseResourceTest.php
@@ -13,6 +13,7 @@ use ReflectionObject;
 
 /**
  * @covers \DigitalCz\DigiSign\Resource\BaseResource
+ * @covers \DigitalCz\DigiSign\Resource\PreciseDateTime
  */
 class BaseResourceTest extends TestCase
 {
@@ -37,6 +38,7 @@ class BaseResourceTest extends TestCase
         ],
         'dateTime' => '2021-01-01T01:01:01+00:00',
         'dateTimeNullable' => '2021-01-01T01:01:01+00:00',
+        'preciseDateTime' => '2021-01-01T01:01:01.001+00:00',
         'collection' => [
             [
                 'id' => null,
@@ -82,6 +84,7 @@ class BaseResourceTest extends TestCase
         self::assertEquals('2021-01-01T01:01:01+00:00', $resource->dateTime->format(DateTimeInterface::ATOM));
         self::assertInstanceOf(DateTimeInterface::class, $resource->dateTimeNullable);
         self::assertEquals('2021-01-01T01:01:01+00:00', $resource->dateTimeNullable->format(DateTimeInterface::ATOM));
+        self::assertEquals('2021-01-01T01:01:01.001+00:00', $resource->preciseDateTime->format('Y-m-d\TH:i:s.vP'));
         self::assertCount(2, $resource->collection);
         self::assertInstanceOf(DummyResource::class, $resource->collection[0]);
         self::assertSame('moo', $resource->collection[0]->string);

--- a/tests/Resource/BaseResourceTest.php
+++ b/tests/Resource/BaseResourceTest.php
@@ -84,7 +84,10 @@ class BaseResourceTest extends TestCase
         self::assertEquals('2021-01-01T01:01:01+00:00', $resource->dateTime->format(DateTimeInterface::ATOM));
         self::assertInstanceOf(DateTimeInterface::class, $resource->dateTimeNullable);
         self::assertEquals('2021-01-01T01:01:01+00:00', $resource->dateTimeNullable->format(DateTimeInterface::ATOM));
-        self::assertEquals('2021-01-01T01:01:01.001+00:00', $resource->preciseDateTime->format('Y-m-d\TH:i:s.vP'));
+        self::assertEquals(
+            '2021-01-01T01:01:01.001+00:00',
+            $resource->preciseDateTime->format(PreciseDateTime::MILLIS),
+        );
         self::assertCount(2, $resource->collection);
         self::assertInstanceOf(DummyResource::class, $resource->collection[0]);
         self::assertSame('moo', $resource->collection[0]->string);

--- a/tests/Resource/DummyResource.php
+++ b/tests/Resource/DummyResource.php
@@ -24,6 +24,7 @@ class DummyResource extends BaseResource
         ],
         'dateTime' => '2021-01-01T01:01:01+00:00',
         'dateTimeNullable' => '2021-01-01T01:01:01+00:00',
+        'preciseDateTime' => '2021-01-01T01:01:01.001+00:00',
         'collection' => [
             ['string' => 'moo'],
             ['string' => 'baz'],
@@ -71,6 +72,8 @@ class DummyResource extends BaseResource
     public DateTime $dateTime;
 
     public ?DateTime $dateTimeNullable;
+
+    public PreciseDateTime $preciseDateTime;
 
     /** @var Collection<DummyResource> */
     public Collection $collection;


### PR DESCRIPTION
## Description

  Added PreciseDateTime class to support DateTime serialization with milliseconds. This allows resources to explicitly indicate when they need millisecond precision
  in their DateTime properties, while maintaining backward compatibility with standard DateTime formatting.

 ## Key changes:
  - New PreciseDateTime class that extends DateTime
  - Updated BaseResource::toArray() to handle PreciseDateTime with millisecond formatting (Y-m-d\TH:i:s.vP)
  - Enhanced BaseResource::setProperty() hydration to support PreciseDateTime type
  - Updated AccountRequest resource to use PreciseDateTime for requestTime and responseTime properties
  - Added comprehensive test coverage
