### PR TITLE
Release 2.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,15 @@ All notable changes will be documented in this file.
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
 ## [Unreleased]
-- [DEPRECATION] `testing` parameter and `useTesting()` method are deprecated, use `sandbox` parameter and `useSandbox()` method instead
-- [DEPRECATION] `API_BASE_TESTING` constant is deprecated, use `API_BASE_SANDBOX` instead
+
+## [2.11.0] - 2025-11-12
+
+### Deprecated
+- `testing` parameter and `useTesting()` method are deprecated, use `sandbox` parameter and `useSandbox()` method instead
+- `API_BASE_TESTING` constant is deprecated, use `API_BASE_SANDBOX` instead
 - Drop official PHP 8.0 support (no longer tested in CI, but still allowed in composer.json)
+
+### Added
 - Add `sandbox` parameter to constructor options for switching to sandbox environment
 - Add `API_BASE_SANDBOX` constant for sandbox API base URL
 - Add `ContactImport.importedfields` property

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Add `AccountBrandingsEndpoint.info` endpoint
 - Add `User.invitedAt` property
 - Specify `BatchSending.importFields` property type
+- Change testing base url
 
 ## [2.9.0] - 2025-10-03
 - [BREAKING-CHANGE] Fix `WebhookAttempt.status` type from string to int

--- a/src/DigiSign.php
+++ b/src/DigiSign.php
@@ -32,7 +32,7 @@ use Psr\SimpleCache\CacheInterface;
 
 final class DigiSign implements EndpointInterface
 {
-    public const VERSION = '2.10.0';
+    public const VERSION = '2.11.0';
     public const API_BASE = 'https://api.digisign.org';
     public const API_BASE_SANDBOX = 'https://api.staging.digisign.org';
 


### PR DESCRIPTION
## Change: Replaced testing with staging and introduced a universal sandbox environment

### Summary of changes:

- Updated API URL from https://api.testing.digisign.org → https://api.staging.digisign.org.
- Replaced the testing parameter with the new staging parameter.
- Introduced a universal sandbox parameter, which currently points to the environment intended for client use.
- Backward compatibility preserved: all testing methods remain functional until the next major release.
- PHP 8.0 officially deprecated: all CI checks for PHP 8.0 have been removed.

### Reason for the change:
We wanted to avoid using the dedicated staging parameter and instead introduce a more flexible sandbox option that can serve as a general-purpose environment for client testing.
At the same time, we are discontinuing PHP 8.0 support to streamline maintenance and align with the versions officially supported by the framework and dependencies.