### PR TITLE
Add SubjectProfile resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes will be documented in this file.
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
 ## [Unreleased]
+- Add `SubjectProfile` resource
+- Add `AccountSettings.auditLogSubjectProfile` property
 - Add `NotificationChannels.afterSent` property
 - Add `NotificationChannels.envelopeNotification` property
 - Add `AccountBilling.bankIdSign` property

--- a/src/Resource/AccountSettings.php
+++ b/src/Resource/AccountSettings.php
@@ -28,6 +28,8 @@ class AccountSettings extends BaseResource
 
     public ?Address $address = null;
 
+    public ?SubjectProfile $auditLogSubjectProfile = null;
+
     public string $bankIdProduct;
 
     public bool $bankIdSign;

--- a/src/Resource/SubjectProfile.php
+++ b/src/Resource/SubjectProfile.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCz\DigiSign\Resource;
+
+final class SubjectProfile extends BaseResource
+{
+    public ?string $companyName = null;
+    public ?string $email = null;
+    public Address $address;
+    public ?string $identificationNumber = null;
+    public ?string $vatNumber = null;
+}


### PR DESCRIPTION
## Summary
- Add `SubjectProfile` resource class for the `auditLogSubjectProfile` nested object in AccountSettings API response
- Add `auditLogSubjectProfile` property to `AccountSettings` resource
- Update CHANGELOG.md

## Test plan
- [x] PHPUnit tests pass
- [x] PHPStan static analysis passes (errors only in unrelated `examples/` files)
- [ ] Verify API response hydration with real API call

🤖 Generated with [Claude Code](https://claude.com/claude-code)