### PR TITLE
Remove `EnvelopeTemplate.defaultTimestampDocuments` in favor of properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,9 +48,8 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Add `EnvelopeDocument.timestampEnabled` and `EnvelopeDocument.timestampsRenewalPeriod` properties
 - Add `EnvelopeTemplateDocument.timestampEnabled` and `EnvelopeTemplateDocument.timestampsRenewalPeriod` properties
 - Add `EnvelopeProperties.defaultTimestampDocuments` and `EnvelopeProperties.timestampAuditLogRenewalPeriod` properties
-- Add `EnvelopeTemplate.defaultTimestampDocuments` property
 - Deprecate `EnvelopeProperties.timestampDocuments` in favor of `EnvelopeProperties.defaultTimestampDocuments`
-- Deprecate `EnvelopeTemplate.timestampDocuments` in favor of `EnvelopeTemplate.defaultTimestampDocuments`
+- Deprecate `EnvelopeTemplate.timestampDocuments` in favor of `EnvelopeProperties.defaultTimestampDocuments`
 - Add `Envelope.withdrawalDeadline` property
 
 ## [2.11.0] - 2025-11-12

--- a/src/Resource/EnvelopeTemplate.php
+++ b/src/Resource/EnvelopeTemplate.php
@@ -47,9 +47,7 @@ class EnvelopeTemplate extends BaseResource
 
     public string $channelForDownload;
 
-    public bool $defaultTimestampDocuments;
-
-    /** @deprecated Use $defaultTimestampDocuments instead */
+    /** @deprecated Use EnvelopeProperties::$defaultTimestampDocuments instead */
     public bool $timestampDocuments;
 
     public bool $sendCompleted;


### PR DESCRIPTION
Follow-up to #417 — review on the API MR concluded the default timestamp setting must live only on `EnvelopeProperties`, not as a new top-level field. The API keeps the deprecated top-level `timestampDocuments` alias until a follow-up ticket removes it.

- Remove `EnvelopeTemplate.defaultTimestampDocuments` (unreleased, added in #417)
- Point the `EnvelopeTemplate.timestampDocuments` deprecation to `EnvelopeProperties.defaultTimestampDocuments`
- Update CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)